### PR TITLE
Updates to exportSelChan,flattenSelChan,ConvertToPaintable - see comments

### DIFF
--- a/jtools/convert_selected_to_paintable.py
+++ b/jtools/convert_selected_to_paintable.py
@@ -23,73 +23,28 @@
 # ------------------------------------------------------------------------------
 # ------------------------------------------------------------------------------
 
+
 import mari
-import PySide.QtGui as QtGui
 
-version = "0.04"
+version = "0.01"
+
+
+# ------------------------------------------------------------------------------    
+# The following are used to find multi selections no matter where in the Mari Interface:
+# returnTru(),getLayerList(),findLayerSelection()
+# 
+# This is to support a) Layered Shader Stacks b) deeply nested stacks (maskstack,adjustment stacks),
+# as well as cases where users are working in pinned or docked channels without it being the current channel
 
 # ------------------------------------------------------------------------------
-class ConvertToPaintableUI(QtGui.QDialog):
-    "Create ConvertToPaintableUI"
-    def __init__(self, parent=None):
-        super(ConvertToPaintableUI, self).__init__(parent)
 
-        #Set title and create the major layouts
-        self.setWindowTitle('Convert To Paintable')
-        main_layout = QtGui.QVBoxLayout()
-        button_layout = QtGui.QHBoxLayout()
-
-        message = QtGui.QLabel("Are you sure you wish to convert the selected layers to paintable?")
-        yes = QtGui.QPushButton('Yes')
-        no = QtGui.QPushButton('no')
-        yes.clicked.connect(self.accept)
-        no.clicked.connect(self.reject)
-
-        button_layout.addWidget(yes)
-        button_layout.addWidget(no)
-        main_layout.addWidget(message)
-        main_layout.addLayout(button_layout)
-        self.setLayout(main_layout)
-
-# ------------------------------------------------------------------------------
-def convertSelectedToPaintable():
-    "Convert selected layers to paintable layers."
-    if not isProjectSuitable(): #Check if project is suitable
-        return False
-    
-    #Create dialog and return inputs
-    dialog = ConvertToPaintableUI()
-    if not dialog.exec_():
-        return
-
-    geo = mari.geo.current()
-    channel = geo.currentChannel()
-    layer_list = getLayerList(channel.layerList(), returnTrue)
-    selected = getSelected(layer_list)
-        
-    for layer in selected:
-        layer.makeCurrent()
-        convertToPaintable = mari.actions.get('/Mari/Layers/Convert To Paintable')
-        convertToPaintable.trigger()
-                
-# ------------------------------------------------------------------------------    
-def getSelected(layer_list):
-    "Returns a list of selected layers."
-    matching = []
-    for layer in layer_list:
-        if layer.isSelected():
-            matching.append(layer)
-            
-    return matching
-    
-# ------------------------------------------------------------------------------    
 def returnTrue(layer):
-    "Returns True for any object passed to it."
+    """Returns True for any object passed to it."""
     return True
     
 # ------------------------------------------------------------------------------
 def getLayerList(layer_list, criterionFn):
-    "Returns a list of all of the layers in the stack that match the given criterion function, including substacks."
+    """Returns a list of all of the layers in the stack that match the given criterion function, including substacks."""
     matching = []
     for layer in layer_list:
         if criterionFn(layer):
@@ -102,6 +57,70 @@ def getLayerList(layer_list, criterionFn):
             matching.extend(getLayerList(layer.adjustmentStack().layerList(), criterionFn))
         
     return matching
+# ------------------------------------------------------------------------------
+
+def findLayerSelection():
+    """Searches for the current selection if mari.current.layer is not the same as layer.isSelected"""
+    
+    curGeo = mari.geo.current()
+    curChannel = curGeo.currentChannel()
+    channels = curGeo.channelList()
+    curLayer = mari.current.layer()
+    layers = ()
+    layerSelList = []
+    chn_layerList = ()
+    
+    layerSelect = False
+     
+    if curLayer.isSelected():
+   
+        chn_layerList = curChannel.layerList()
+        layers = getLayerList(chn_layerList,returnTrue)
+        
+        for layer in layers:
+    
+            if layer.isSelected():
+
+                layerSelList.append(layer)
+                layerSelect = True       
+
+    else:
+    
+        for channel in channels:
+            
+            chn_layerList = channel.layerList()
+            layers = getLayerList(chn_layerList,returnTrue)
+        
+            for layer in layers:
+    
+                if layer.isSelected():
+                    curLayer = layer
+                    curChannel = channel
+                    layerSelList.append(layer)
+                    layerSelect = True
+
+    
+    if not layerSelect:
+        mari.utils.message('No Layer Selection found. \n \n Please select at least one Layer.')
+
+
+    return curGeo,curLayer,curChannel,layerSelList
+
+
+# ------------------------------------------------------------------------------
+def convertToPaintable():
+    "Convert selected layers to paintable layers."
+    if not isProjectSuitable(): #Check if project is suitable
+        return False
+    
+    geo_data = findLayerSelection()
+    selected = geo_data[3]
+        
+    for layer in selected:
+        layer.makeCurrent()
+        convertToPaintable = mari.actions.get('/Mari/Layers/Convert To Paintable')
+        convertToPaintable.trigger()
+                
     
 # ------------------------------------------------------------------------------
 def isProjectSuitable():
@@ -130,12 +149,12 @@ def isProjectSuitable():
         return True
         
     else:
-        mari.utils.message("You can only run this script in Mari 2.0v1 or newer.")
+        mari.utils.message("You can only run this script in Mari 2.6v3 or newer.")
         return False
 
 # ------------------------------------------------------------------------------
 if __name__ == "__main__":
-    convertSelectedToPaintable()
+    convertToPaintable()
 
 # ------------------------------------------------------------------------------
 # Add action to Mari menu.


### PR DESCRIPTION
## Export Selected Channels + Duplicate Flatten Channels

The currently active channel will be pre-selected in the interface

Objects + Channels are now sorted alphabetically to be in line with
Mari's Object and Channels Palettes.

Only channels from the current object will be displayed by default now.
A new checkbox 'List all Objects' was added  to return to the previous
behavior.
The current object's channels will be bumped to the top of the list.

Channels (with cryptic names) created by layeredShader stacks will no
longer appear in the list
## Convert to paintable

The interface was removed. Since it is so heavily used it is easier and
less time consuming for users to just make it work off the selection

Some additional logic was built in to make it work with floating/pinned
and docked channels that are not currently the active channel but are
accessible for the user in the interface
